### PR TITLE
Add startup_delay to the config

### DIFF
--- a/agent/conf.go
+++ b/agent/conf.go
@@ -12,8 +12,9 @@ type Conf struct {
 	LogPath    string `toml:"log_path"`
 	ServerName string `toml:"server_name"`
 	detect.LinuxOSInfo
-	Files      []*FileConf `toml:"files"`
-	ServerConf *ServerConf `toml:"-"`
+	Files        []*FileConf `toml:"files"`
+	StartupDelay int         `toml:"startup_delay"`
+	ServerConf   *ServerConf `toml:"-"`
 }
 
 type FileConf struct {

--- a/main.go
+++ b/main.go
@@ -133,6 +133,12 @@ func initialize(env *agent.Env) *agent.Agent {
 
 	// Now that we're registered,
 	// let's init our watchers. We auto sync on watcher init.
+	// If the config sets a startup delay, we wait to boot up here
+	if conf.StartupDelay != 0 {
+		delay := time.Duration(conf.StartupDelay) * time.Second
+		tick := time.Tick(delay)
+		<-tick
+	}
 	a.BuildAndSyncWatchers()
 	return a
 }

--- a/main.go
+++ b/main.go
@@ -113,6 +113,13 @@ func initialize(env *agent.Env) *agent.Agent {
 		log.Fatal("There's no API key set. Get yours from https://appcanary.com/settings and set it in /etc/appcanary/agent.conf")
 	}
 
+	// If the config sets a startup delay, we wait to boot up here
+	if conf.StartupDelay != 0 {
+		delay := time.Duration(conf.StartupDelay) * time.Second
+		tick := time.Tick(delay)
+		<-tick
+	}
+
 	a := agent.NewAgent(CanaryVersion, conf)
 	a.DoneChannel = make(chan os.Signal, 1)
 
@@ -133,12 +140,6 @@ func initialize(env *agent.Env) *agent.Agent {
 
 	// Now that we're registered,
 	// let's init our watchers. We auto sync on watcher init.
-	// If the config sets a startup delay, we wait to boot up here
-	if conf.StartupDelay != 0 {
-		delay := time.Duration(conf.StartupDelay) * time.Second
-		tick := time.Tick(delay)
-		<-tick
-	}
 	a.BuildAndSyncWatchers()
 	return a
 }


### PR DESCRIPTION
startup_delay in the config lets you set how many seconds to wait before
first sync. This is if you're provisioning a new server with appcanary
and you want to give updates time to run