### PR TITLE
Support CentOS Upgrades

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -103,19 +103,21 @@ func (agent *Agent) RegisterServer() error {
 
 func (agent *Agent) PerformUpgrade() {
 	var cmds UpgradeSequence
-	package_list, err := agent.client.FetchUpgradeablePackages()
+	packageList, err := agent.client.FetchUpgradeablePackages()
 
 	if err != nil {
 		log.Fatalf("Can't fetch upgrade info: %s", err)
 	}
 
-	if len(package_list) == 0 {
+	if len(packageList) == 0 {
 		log.Info("No vulnerable packages reported. Carry on!")
 		return
 	}
 
 	if agent.server.IsUbuntu() {
-		cmds = buildDebianUpgrade(package_list)
+		cmds = buildDebianUpgrade(packageList)
+	} else if agent.server.IsCentOS() {
+		cmds = buildCentOSUpgrade(packageList)
 	} else {
 		log.Fatal("Sorry, we don't support your operating system at the moment. Is this a mistake? Run `appcanary detect-os` and tell us about it at support@appcanary.com")
 	}

--- a/agent/server.go
+++ b/agent/server.go
@@ -79,3 +79,7 @@ func (server *Server) IsNew() bool {
 func (server *Server) IsUbuntu() bool {
 	return server.Distro == "ubuntu"
 }
+
+func (server *Server) IsCentOS() bool {
+	return server.Distro == "centos"
+}

--- a/agent/upgrade.go
+++ b/agent/upgrade.go
@@ -14,7 +14,18 @@ type UpgradeCommand struct {
 
 type UpgradeSequence []UpgradeCommand
 
-func buildDebianUpgrade(package_list map[string]string) UpgradeSequence {
+func buildCentOSUpgrade(packageList map[string]string) UpgradeSequence {
+	installCmd := "yum"
+	installArg := []string{"update-to", "--assumeyes"}
+
+	for name, _ := range packageList {
+		installArg = append(installArg, strings.TrimSuffix(packageList[name], ".rpm"))
+	}
+
+	return UpgradeSequence{UpgradeCommand{installCmd, installArg}}
+}
+
+func buildDebianUpgrade(packageList map[string]string) UpgradeSequence {
 	updateCmd := "apt-get"
 	updateArg := []string{"update", "-q"}
 
@@ -29,7 +40,7 @@ func buildDebianUpgrade(package_list map[string]string) UpgradeSequence {
 		installArg = append(installArg, "-o Dpkg::Options::=\"--force-confdef\"", "-o Dpkg::Options::=\"--force-confold\"")
 	}
 
-	for name, _ := range package_list {
+	for name, _ := range packageList {
 		// for now let's just stick to blanket updates
 		// to the packages. At a glance, it seems in ubuntu land you only
 		// get access to the most recent version anyways.

--- a/agent/upgrade_test.go
+++ b/agent/upgrade_test.go
@@ -9,15 +9,30 @@ import (
 func TestBuildDebianUpgrade(t *testing.T) {
 	assert := assert.New(t)
 
-	package_list := map[string]string{"foobar": "version"}
-	commands := buildDebianUpgrade(package_list)
+	packageList := map[string]string{"foobar": "version"}
+	commands := buildDebianUpgrade(packageList)
 
 	assert.Equal(2, len(commands))
 	assert.Equal("apt-get", commands[0].Name)
 	assert.Equal("apt-get", commands[1].Name)
 
-	upgrade_args := commands[1].Args
-	last_arg := upgrade_args[len(upgrade_args)-1]
+	upgradeArgs := commands[1].Args
+	lastArg := upgradeArgs[len(upgradeArgs)-1]
 
-	assert.Equal("foobar", last_arg)
+	assert.Equal("foobar", lastArg)
+}
+
+func TestBuildCentOSUpgrade(t *testing.T) {
+	assert := assert.New(t)
+
+	packageList := map[string]string{"foobar": "version"}
+	commands := buildCentOSUpgrade(packageList)
+
+	assert.Equal(1, len(commands))
+	assert.Equal("yum", commands[0].Name)
+
+	upgradeArgs := commands[0].Args
+	lastArg := upgradeArgs[len(upgradeArgs)-1]
+
+	assert.Equal("foobar-version", lastArg)
 }

--- a/agent/upgrade_test.go
+++ b/agent/upgrade_test.go
@@ -22,7 +22,7 @@ func TestBuildDebianUpgrade(t *testing.T) {
 	assert.Equal("foobar", lastArg)
 }
 
-func TestBuildCentOSUpgrade(t *testing.T) {
+func TestBuildCentOSUpgradeWithSuffixedVersion(t *testing.T) {
 	assert := assert.New(t)
 
 	packageList := map[string]string{"foobar": "foobar-version-with-suffix.rpm"}
@@ -35,4 +35,19 @@ func TestBuildCentOSUpgrade(t *testing.T) {
 	lastArg := upgradeArgs[len(upgradeArgs)-1]
 
 	assert.Equal("foobar-version-with-suffix", lastArg)
+}
+
+func TestBuildCentOSUpgradeWithoutSuffixedVersion(t *testing.T) {
+	assert := assert.New(t)
+
+	packageList := map[string]string{"foobar": "foobar-version-without-suffix"}
+	commands := buildCentOSUpgrade(packageList)
+
+	assert.Equal(1, len(commands))
+	assert.Equal("yum", commands[0].Name)
+
+	upgradeArgs := commands[0].Args
+	lastArg := upgradeArgs[len(upgradeArgs)-1]
+
+	assert.Equal("foobar-version-without-suffix", lastArg)
 }

--- a/agent/upgrade_test.go
+++ b/agent/upgrade_test.go
@@ -25,7 +25,7 @@ func TestBuildDebianUpgrade(t *testing.T) {
 func TestBuildCentOSUpgrade(t *testing.T) {
 	assert := assert.New(t)
 
-	packageList := map[string]string{"foobar": "version"}
+	packageList := map[string]string{"foobar": "foobar-version-with-suffix.rpm"}
 	commands := buildCentOSUpgrade(packageList)
 
 	assert.Equal(1, len(commands))
@@ -34,5 +34,5 @@ func TestBuildCentOSUpgrade(t *testing.T) {
 	upgradeArgs := commands[0].Args
 	lastArg := upgradeArgs[len(upgradeArgs)-1]
 
-	assert.Equal("foobar-version", lastArg)
+	assert.Equal("foobar-version-with-suffix", lastArg)
 }


### PR DESCRIPTION
This seems to "just work" with the values supplied by the existing process. Couple things:

1. The map provided as `packageList` appears to contain package/version pairs where the version contains the entire package name plus a `.rpm` suffix.
2. I'm not doing any metadata update (a la `apt-get update`) because I don't see how `yum` does that. It seems to sync as part of other operations.
3. I'm not dealing with conflicts or configuration stomping. I need to investigate that a bit.

This is mergeable without regression, but let's discuss at least point number 3 above.