### PR TITLE
Don't cache release and distro

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -126,6 +126,7 @@ func (agent *Agent) RegisterServer() error {
 	if err != nil {
 		return err
 	}
+
 	agent.server.UUID = uuid
 	agent.conf.ServerConf.UUID = uuid
 	agent.conf.Save()

--- a/agent/client.go
+++ b/agent/client.go
@@ -44,11 +44,12 @@ func NewClient(apiKey string, server *Server) *CanaryClient {
 func (client *CanaryClient) Heartbeat(uuid string, files Watchers) error {
 	log := conf.FetchLog()
 
+	server := client.server.WithOSInfo()
 	body, err := json.Marshal(map[string]interface{}{
 		"files":         files,
 		"agent-version": CanaryVersion,
-		"distro":        client.server.Distro,
-		"release":       client.server.Release,
+		"distro":        server.Distro,
+		"release":       server.Release,
 	})
 
 	if err != nil {
@@ -111,7 +112,7 @@ func (client *CanaryClient) SendProcessState(match string, body []byte) error {
 }
 
 func (c *CanaryClient) CreateServer(srv *Server) (string, error) {
-	body, err := json.Marshal(*srv)
+	body, err := json.Marshal(*srv.WithOSInfo())
 
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This changes things so that unless the distro and release are set in the configuration file, the detect code runs every time it is sent to coalmine.

Note that we decided this was unnecessary, but I had already done the work. Doing the same for `hostname` would be easy. This can be closed if necessary.