### PR TITLE
Fix packaging for yaml

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -67,8 +67,9 @@ task :cross_compile => :release_prep do
   puts "Cross compiling packages."
   puts "#################################\n\n\n"
 
-  @ldflags = %{-X main.CanaryVersion='#{@release_version}'}
-  shell %{goxc -build-ldflags="#{@ldflags}" -arch="amd64,386" -bc="linux" -os="linux" -pv="#{@release_version}"  -d="dist/" xc}
+  @ldflags = %{"-X main.CanaryVersion=#{@release_version}"}
+  shell %{env GOARCH=386 GOOS=linux go build -ldflags #{@ldflags} -o dist/#{@release_version}/linux_i386/appcanary github.com/appcanary/agent}
+  shell %{env GOARCH=amd64 GOOS=linux go build -ldflags #{@ldflags} -o dist/#{@release_version}/linux_amd64/appcanary github.com/appcanary/agent}
 end
 
 

--- a/conf/common.go
+++ b/conf/common.go
@@ -20,7 +20,7 @@ type Conf struct {
 	Watchers           []WatcherConf `yaml:"watchers" toml:"files"`
 	StartupDelay       int           `yaml:"startup_delay,omitempty" toml:"startup_delay"`
 	ServerConf         *ServerConf   `yaml:"-" toml:"-"`
-	Tags               []string      `yaml:"tags"` // no toml support for this
+	Tags               []string      `yaml:"tags,omitempty"` // no toml support for this
 }
 
 type WatcherConf struct {

--- a/package/packager_mgmt.rb
+++ b/package/packager_mgmt.rb
@@ -1,6 +1,6 @@
 class Packager
-  CONFIG_FILES = {"config/etc/appcanary/agent.yml" => "/etc/appcanary/agent.yml",  
-                  "config/var/db/appcanary/server.yml" => "/var/db/appcanary/server.yml"}
+  CONFIG_FILES = {"config/etc/appcanary/agent.yml" => "/etc/appcanary/agent.yml.sample",
+                  "config/var/db/appcanary/server.yml" => "/var/db/appcanary/server.yml.sample"}
   DIRECTORIES = ["/etc/appcanary/", "/var/db/appcanary/"]
   ARCHS = ["amd64", "i386"]
 

--- a/package/packager_mgmt.rb
+++ b/package/packager_mgmt.rb
@@ -59,9 +59,8 @@ class PackageBuilder
       "#{p.dir_args}",                # use the following directories when building
       "#{p.post_install_files}",      # after install, use this file
       "--license #{LICENSE} --vendor #{VENDOR}",
-      "#{p.list_config_files}",       # mark these files as being config
       "./ #{p.bin_file}",             # where should the binary be copied to?
-      "#{p.config_files_path}"        # where are the config files marked above?
+      "#{p.config_files_path}"        # find the config files to install
     ].join(" ")
 
     execute build_cmd

--- a/package/packager_models.rb
+++ b/package/packager_models.rb
@@ -30,10 +30,6 @@ class PrePackage
     config_files.map {|k, v| "../../../#{k}=#{v}" }.join(" ")
   end
 
-  def list_config_files
-    config_files.map { |k, v| "--config-files #{v} "}.join(" ")
-  end
-
   def full_distro_name
     "#{distro}_#{release}"
   end

--- a/package/packager_models.rb
+++ b/package/packager_models.rb
@@ -42,17 +42,10 @@ class PrePackage
     "releases/appcanary_#{version}_#{arch}_#{full_distro_name}.#{package_type}" 
   end
 
-    
-  def arch_dir
-    # GOXC uses '386' while fpm uses 'i386'. arch => directory it's in
-    {"amd64" => "amd64",
-     "i386" => "386"}[arch]
-  end
-
   # also, remember to document things. why is this
   # four layers deep?
   def bin_path
-    "../../../../dist/#{version}/linux_#{arch_dir}/appcanary"
+    "../../../../dist/#{version}/linux_#{arch}/appcanary"
   end
 
   def bin_file

--- a/package/packager_recipes.rb
+++ b/package/packager_recipes.rb
@@ -2,8 +2,8 @@ class UbuntuRecipe < Packager
   self.distro = "ubuntu"
   self.releases = "trusty", "precise", "vivid", "utopic", "wily", "xenial", "yakkety"
   self.package_type = "deb"
-  CONFIG_FILES = {"config/etc/appcanary/dpkg.agent.yml" => "/etc/appcanary/agent.yml",
-                  "config/var/db/appcanary/server.yml" => "/var/db/appcanary/server.yml"}
+  CONFIG_FILES = {"config/etc/appcanary/dpkg.agent.yml" => "/etc/appcanary/agent.yml.sample",
+                  "config/var/db/appcanary/server.yml" => "/var/db/appcanary/server.yml.sample"}
 end
 
 # amazon/2015.03 == el/6 so perhaps
@@ -12,8 +12,8 @@ end
 #   self.distro = "amazon"
 #   self.releases = ["2015.03", "2015.09", "2016.03"]
 #   self.package_type ="rpm"
-#   CONFIG_FILES = {"config/etc/appcanary/rpm.agent.yml" => "/etc/appcanary/agent.yml",
-#                   "config/var/db/appcanary/server.yml" => "/var/db/appcanary/server.yml"}
+#   CONFIG_FILES = {"config/etc/appcanary/rpm.agent.yml" => "/etc/appcanary/agent.yml.sample",
+#                   "config/var/db/appcanary/server.yml" => "/var/db/appcanary/server.yml.sample"}
 # end
 
 class CentosRecipe < Packager
@@ -29,8 +29,8 @@ class Centos7Recipe < Packager
   self.releases = ["7"]
   self.package_type = "rpm"
 
-  CONFIG_FILES = {"config/etc/appcanary/rpm.agent.yml" => "/etc/appcanary/agent.yml",
-                  "config/var/db/appcanary/server.yml" => "/var/db/appcanary/server.yml"}
+  CONFIG_FILES = {"config/etc/appcanary/rpm.agent.yml" => "/etc/appcanary/agent.yml.sample",
+                  "config/var/db/appcanary/server.yml" => "/var/db/appcanary/server.yml.sample"}
 end
 
 
@@ -44,8 +44,8 @@ class DebianRecipe < Packager
   self.distro =  "debian"
   self.releases = ["jessie", "wheezy", "squeeze"]
   self.package_type = "deb"
-  CONFIG_FILES = {"config/etc/appcanary/dpkg.agent.yml" => "/etc/appcanary/agent.yml",
-                  "config/var/db/appcanary/server.yml" => "/var/db/appcanary/server.yml"}
+  CONFIG_FILES = {"config/etc/appcanary/dpkg.agent.yml" => "/etc/appcanary/agent.yml.sample",
+                  "config/var/db/appcanary/server.yml" => "/var/db/appcanary/server.yml.sample"}
 end
 
 class MintRecipe < Packager


### PR DESCRIPTION
In this PR we stop installing a broken (incomplete template) config file and instead install the template with a `.sample` extension. This allows the agent to successfully convert an old configuration if one exists, avoiding ignoring the old configuration and loading a broken configuration on restart.

In addition, I've tweaked the config struct so it doesn't dump empty tag lists when it converts the configuration.

Finally, there is one possible gotcha - when you purge a package, it leaves in place files it doesn't know about; this includes `agent.conf.deprecated`, but also the actual `agent.yml`, because the files now marked as config files in the package have the `.sample` extension, e.g., `agent.yml.sample`. This is fairly minor, but I'm not sure if there are other consequences of this change. Would it be appropriate to add the `.yml` files into the list of config files? Resulting in the following list:

* `/etc/appcanary/agent.yml`
* `/etc/appcanary/agent.yml.sample`
* `/var/db/appcanary/server.yml`
* `/var/db/appcanary/server.yml.sample`

being treated as config files. Note that doing this would still leave `*.conf.deprecated` in place, unremoved.